### PR TITLE
Fix reload external client tokens

### DIFF
--- a/src/main/java/fi/jubic/quanta/App.java
+++ b/src/main/java/fi/jubic/quanta/App.java
@@ -110,6 +110,6 @@ public class App implements AuthenticatedApplication<User> {
         taskScheduler.start();
 
         new UndertowServer().start(app, configuration);
-
+        app.authenticator.reloadExternalClients();
     }
 }

--- a/src/main/java/fi/jubic/quanta/models/QuantaAuthenticator.java
+++ b/src/main/java/fi/jubic/quanta/models/QuantaAuthenticator.java
@@ -22,7 +22,6 @@ public class QuantaAuthenticator extends StatefulAuthenticator<User> {
     ) {
         this.tokens = new CopyOnWriteArrayList<>();
         this.externalClientController = externalClientController;
-        reloadExternalClients();
     }
 
     @Override


### PR DESCRIPTION
Only load external client tokens after the application
finishes the migration