### PR TITLE
Fix time column format parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix Timestamp to Instant conversion when querying data.
 
 ## [0.3.1] - 2021-07-14
 ### Changed

--- a/src/main/java/fi/jubic/quanta/dao/TimeSeriesDao.java
+++ b/src/main/java/fi/jubic/quanta/dao/TimeSeriesDao.java
@@ -1703,15 +1703,28 @@ public class TimeSeriesDao {
 
             String valueKey = columnSelectorOfIndex.getWorkerDefColumn().getName();
 
-            values.put(
-                    valueKey,
-                    record.get(
-                            offset + selectIndex,
-                            columnSelectorOfIndex
-                                    .getType()
-                                    .getClassName()
-                    )
-            );
+            if (
+                    columnSelectorOfIndex
+                            .getType()
+                            .getClassName()
+                            == Instant.class
+            ) {
+                values.put(
+                        valueKey,
+                        record.get(TIME_BUCKET_FIELD).toInstant()
+                );
+            }
+            else {
+                values.put(
+                        valueKey,
+                        record.get(
+                                offset + selectIndex,
+                                columnSelectorOfIndex
+                                        .getType()
+                                        .getClassName()
+                        )
+                );
+            }
         }
 
         if (values.isEmpty()) return Optional.empty();


### PR DESCRIPTION
JOOQ can not convert directly from type Object or Instant to Timestamp type
Parse Instant class to TIME_BUCKET_FIELD