### PR TITLE
Exclude distinct fields from selected fields

### DIFF
--- a/src/main/java/fi/jubic/quanta/dao/TimeSeriesDao.java
+++ b/src/main/java/fi/jubic/quanta/dao/TimeSeriesDao.java
@@ -594,6 +594,10 @@ public class TimeSeriesDao {
         ).collect(Collectors.toList());
 
         List<Field<?>> selectFields = selectColumns.stream()
+                .filter(columnSelector -> !Objects.equals(
+                        columnSelector.getModifier(),
+                        TimeSeriesModifier.distinct
+                ))
                 .map(columnSelector -> {
                     if (columnSelector.getModifier() != null) {
                         return DSL.field(DSL.sql(
@@ -814,6 +818,10 @@ public class TimeSeriesDao {
 
         List<Field<?>> selectFields = selectColumns.stream()
                 .filter(columnSelector -> columnSelector.getOutputColumn().getIndex() != 0)
+                .filter(columnSelector -> !Objects.equals(
+                        columnSelector.getModifier(),
+                        TimeSeriesModifier.distinct
+                ))
                 .map(columnSelector -> {
                     if (columnSelector.getModifier() != null) {
                         return DSL.field(DSL.sql(


### PR DESCRIPTION
Do not combine distinct aggregation with other selectors, so exclude the
distinct fields from selected fields is required